### PR TITLE
feat(codeowners): Add team merlin to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @anthonyburchell
+* @wpengine/merlin


### PR DESCRIPTION
This PR adds team Merlin to `codeowners` as we plan to take over the ownership of this project.