### PR TITLE
Merl 342 wp coding standards update dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"wp-coding-standards/wpcs": "2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "2.1.3"
+		"wp-coding-standards/wpcs": "^2.3.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.3"
 	},
 	"minimum-stability": "dev",
     "prefer-stable" : true,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"wp-coding-standards/wpcs": "^2",
+		"wp-coding-standards/wpcs": "2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2"
 	},
 	"minimum-stability": "dev",
@@ -50,5 +50,10 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"squizlabs/php_codesniffer": "^3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"wp-coding-standards/wpcs": "2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "^2"
+		"phpcompatibility/phpcompatibility-wp": "2.1.3"
 	},
 	"minimum-stability": "dev",
     "prefer-stable" : true,


### PR DESCRIPTION
**Description:** 

WP Coding standards have had two updates to dependencies in the wpengine-coding-standards repo:
```
"wp-coding-standards/wpcs": "^2.3.0",
"phpcompatibility/phpcompatibility-wp": "^2.1.3"
```
**To test:**

First, ensure that composer is running on your local machine (you can use `brew install composer` to download this)
Ensure the PHP version on your local machine is set to 7.4 with `use php 7.4` or `brew installphp@7.4` in terminal (v8.1.9 introduces breaking changes to the functionality being tested- this will be added to the backlog)
Pull the MERL 342 branch down, and open faustJS in a separate vs code window. 
`cd` into `faustwp` and run ./vendor/bin/phpcs` 
You should see something similar to the below in your terminal: 
![image](https://user-images.githubusercontent.com/50935135/186245755-bf2fb6c4-1e88-4ba9-a28c-ac9a2e55e672.png)

Next, open the faustwp.php file and create a linting error or two in the syntax. for example: 
![image](https://user-images.githubusercontent.com/50935135/186246821-5b62310c-9c2f-43f9-8de8-f9329c4a3dd6.png)

Next, `cd` into `faustwp` and run ./vendor/bin/phpcs` 

If the linter is working correctly, you should see a message like the below in your terminal: 
![image](https://user-images.githubusercontent.com/50935135/186247381-650d7969-536c-47d4-8da6-9e25f3c802c1.png)


