### PR TITLE
Remove duplicate key from composer.json

### DIFF
--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Validate Composer Config
       uses: php-actions/composer@v6
       with:
-        command: validate
+        command: validate --strict

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: php-actions/composer@v6
 

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -3,6 +3,7 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: false
     steps:
     - uses: actions/checkout@v3
     - name: Validate Composer Config

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -3,11 +3,9 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: false
     steps:
     - uses: actions/checkout@v3
+    - uses: shivammathur/setup-php@v2
     - name: Validate Composer Config
-      uses: php-actions/composer@v6
-      with:
-        command: validate
-        only_args: --strict
+      run: |
+        composer validate --strict

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -16,4 +16,5 @@ jobs:
     - name: Validate Composer Config
       uses: php-actions/composer@v6
       with:
-        command: validate --strict
+        command: validate
+        only_args: --strict

--- a/.github/workflows/verify-dependencies-install.yml
+++ b/.github/workflows/verify-dependencies-install.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: shivammathur/setup-php@v2
     - name: Install Dependencies
-      uses: php-actions/composer@v6
-      with:
-        command: install
+      run: |
+        composer install

--- a/.github/workflows/verify-dependencies-install.yml
+++ b/.github/workflows/verify-dependencies-install.yml
@@ -1,12 +1,11 @@
-name: Validate Composer Config
+name: Verify Dependencies Install
 on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Validate Composer Config
+    - name: Install Dependencies
       uses: php-actions/composer@v6
       with:
-        command: validate
-        only_args: --strict
+        command: install

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,5 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
-	},
-	"config": {
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,5 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
-	},
-	"config": {
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,10 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"authors": [
 		{
 			"name": "Contributors",
-			"homepage": "https://github.com/wpengine/wpecs/graphs/contributors"
+			"homepage": "https://github.com/wpengine/wpengine-coding-standards/graphs/contributors"
 		}
 	],
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,10 @@
 		}
 	},
 	"minimum-stability": "dev",
-    "prefer-stable" : true,
+	"prefer-stable" : true,
 	"support": {
-		"issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
-		"wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki",
-		"source": "https://github.com/wpengine/WPEngine-Coding-Standards"
+		"issues": "https://github.com/wpengine/wpengine-coding-standards/issues",
+		"source": "https://github.com/wpengine/wpengine-coding-standards"
 	},
 	"bin": [
 		"bin/wpecs",


### PR DESCRIPTION
## Description

Removes a duplicate config key within this package's composer.json.

Since composer considers duplicate keys as warnings, pull requests were showing false positives. Actions are now directly calling `composer validate --strict`.

Actions can now be seen
- [exiting with warnings and/or errors](https://github.com/wpengine/wpengine-coding-standards/pull/15#:~:text=Verified-,d5dc0ab,-Remove%20duplicate%20key)
- [passing without warnings and/or errors](https://github.com/wpengine/wpengine-coding-standards/pull/15/commits/7e63c69a9c73762f1e0e7797b94fb945500db4f9)

<img width="874" alt="" src="https://user-images.githubusercontent.com/6676674/201122957-27d6a874-78a2-48cc-81cf-1397e508ec17.png">

## Testing

1. Checkout this branch `MERL-608-fix-composerjson`
2. Run `composer validate`