### PR TITLE
Add WPCS develop branch to develop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @anthonyburchell
+* @wpengine/merlin

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: '🐛 Bug Report'
+about: Report a reproducible bug or regression.
+title: 'Bug: '
+labels: 'Status: Unconfirmed'
+---
+
+<!--
+  Please provide a clear and concise description of what the bug is. Include
+  screenshots if needed. Please test using the latest version of this standard library
+  to make sure your issue has not already been fixed.
+-->
+
+### Version information
+- Coding Standards version: x.x.x
+- WordPress version: x.x.x
+- Operating system:
+
+## Steps To Reproduce
+<!-- Any steps, flags, details that can help the team reproduce the issue.-->
+
+1.
+2.
+
+## The current behavior
+<!-- A clear and concise description of the bug goes here. -->
+
+## The expected behavior
+<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: '💬 Feature Request/General Improvements'
+about: Requests for new features, or general improvements
+title: ''
+labels: 'Status: Unconfirmed'
+---
+
+<!--
+  Request new features or improvements here
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+<!--
+Include a summary of the change and some contextual information.
+-->
+
+## Related Issue(s):
+
+<!--
+Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:
+
+- #1234
+-->
+
+## Testing
+
+<!--
+Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
+-->

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -1,0 +1,19 @@
+name: Validate Composer Config
+on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: php-actions/composer@v6
+
+    - name: Install Dependencies
+      uses: php-actions/composer@v6
+      with:
+        command: install
+
+    - name: Validate Composer Config
+      uses: php-actions/composer@v6
+      with:
+        command: validate

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Validate Composer Config
       uses: php-actions/composer@v6
       with:
-        command: validate
+        command: validate --strict

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: php-actions/composer@v6
 

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -3,6 +3,7 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: false
     steps:
     - uses: actions/checkout@v3
     - name: Validate Composer Config

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -3,11 +3,9 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: false
     steps:
     - uses: actions/checkout@v3
+    - uses: shivammathur/setup-php@v2
     - name: Validate Composer Config
-      uses: php-actions/composer@v6
-      with:
-        command: validate
-        only_args: --strict
+      run: |
+        composer validate --strict

--- a/.github/workflows/validate-composer-config.yml
+++ b/.github/workflows/validate-composer-config.yml
@@ -16,4 +16,5 @@ jobs:
     - name: Validate Composer Config
       uses: php-actions/composer@v6
       with:
-        command: validate --strict
+        command: validate
+        only_args: --strict

--- a/.github/workflows/verify-dependencies-install.yml
+++ b/.github/workflows/verify-dependencies-install.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: shivammathur/setup-php@v2
     - name: Install Dependencies
-      uses: php-actions/composer@v6
-      with:
-        command: install
+      run: |
+        composer install

--- a/.github/workflows/verify-dependencies-install.yml
+++ b/.github/workflows/verify-dependencies-install.yml
@@ -1,12 +1,11 @@
-name: Validate Composer Config
+name: Verify Dependencies Install
 on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Validate Composer Config
+    - name: Install Dependencies
       uses: php-actions/composer@v6
       with:
-        command: validate
-        only_args: --strict
+        command: install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Instructions For Logging Issues
+
+## 1. Search For Duplicates
+
+[Search the existing issues](https://github.com/wpengine/wpengine-coding-standards/search?type=Issues) before logging a new one.
+
+## 2. Did You Find A Bug?
+
+When logging a bug, please be sure to include the following:
+
+- What version of the package/plugin are you using
+- If at all possible, an _isolated_ way to reproduce the behavior
+- The behavior you expect to see, and the actual behavior
+
+## 3. Do You Have A Suggestion?
+
+We also accept suggestions in the issue tracker. Be sure to [search](https://github.com/wpengine/wpengine-coding-standards/search?type=Issues) first.
+
+# Instructions For Contributing Code
+
+## What You'll Need
+
+0. [A bug or feature you want to work on](https://github.com/wpengine/wpengine-coding-standards/labels/help%20wanted)! If you have found a new bug or want to propose a feature, please [create an issue](https://github.com/wpengine/wpengine-coding-standards/issues/new/choose) before starting a pull request.
+1. [A GitHub account](https://github.com/join).
+2. The latest working copy of the code.
+
+## Housekeeping
+
+Your pull request should:
+
+- Include a description of what your change intends to do
+- Reference any open issues that the PR addresses
+- Be based on reasonably recent commit in the **master** branch
+- Contain proper [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716#gistcomment-3711094) as follows:
+
+  ```
+    <type>[<scope>]: (<issue #>) <short summary>
+      │      │           |             │
+      |      |           |             └─> Summary in present tense. Not capitalized. No period at the end.
+      |      |           |
+      │      │           └─> Issue # (optional): Issue number if related to bug database.
+      │      │
+      │      └─> Scope (optional): eg. common, compiler, authentication, core
+      │
+      └─> Type: chore, docs, feat, fix, refactor, style, or test.
+  ```
+
+- To avoid line ending issues, set `autocrlf = input` and `whitespace = cr-at-eol` in your git configuration

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,13 @@
+# Development
+
+## Releasing
+
+This project uses GitHub Releases for its release process. Once a release occurs on GitHub, Packagist is automatically notified of the release via a webhook.
+
+Each release should have a title that corresponds to the semantic version. The tag should also correspond to the semantic version, for example "1.0.0". The body should include the release's relevant changes.
+
+For more info on GitHub releases, visit the [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) help doc.
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/).

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,13 @@
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"wp-coding-standards/wpcs": "^2",
-		"phpcompatibility/phpcompatibility-wp": "^2"
+		"wp-coding-standards/wpcs": "^2.3.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.3"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"minimum-stability": "dev",
     "prefer-stable" : true,
@@ -50,5 +55,10 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,5 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
-	},
-	"config": {
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,5 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
-	},
-	"config": {
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,10 @@
 		"check-complete-strict": [
 			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WP-Engine"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php": ">=5.4",
 		"squizlabs/php_codesniffer": "^3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"wp-coding-standards/wpcs": "^2.3.0",
+		"wp-coding-standards/wpcs": "dev-develop",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.3"
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"authors": [
 		{
 			"name": "Contributors",
-			"homepage": "https://github.com/wpengine/wpecs/graphs/contributors"
+			"homepage": "https://github.com/wpengine/wpengine-coding-standards/graphs/contributors"
 		}
 	],
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,10 @@
 		}
 	},
 	"minimum-stability": "dev",
-    "prefer-stable" : true,
+	"prefer-stable" : true,
 	"support": {
-		"issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
-		"wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki",
-		"source": "https://github.com/wpengine/WPEngine-Coding-Standards"
+		"issues": "https://github.com/wpengine/wpengine-coding-standards/issues",
+		"source": "https://github.com/wpengine/wpengine-coding-standards"
 	},
 	"bin": [
 		"bin/wpecs",


### PR DESCRIPTION
## Description

This change adds the develop branch of WPCS to the develop branch of `wpengine-coding-standards`. PHP 8+ is currently only supported within the develop branch of https://github.com/WordPress/WordPress-Coding-Standards